### PR TITLE
Support Naxsi + update versions stable/mainline CVE-2017-7529

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,35 @@
 
 Build and install [Nginx](https://nginx.org) on any UNIX system with the latest version of [OpenSSL](https://www.openssl.org/) to support [ALPN](https://en.wikipedia.org/wiki/Application-Layer_Protocol_Negotiation), and therefore [HTTP/2](https://en.wikipedia.org/wiki/HTTP/2).
 
+## Modules
+
+### Naxsi
+
+[Naxsi](https://www.nbs-system.com/securite-informatique/outils-securite-informatique-open-source/naxsi/) is a web application firewall based in rules files. The module is optional, for enable it, change "no" to "yes" into `data/extras.sh`. It's just a module and default rules (warning, the files `naxsi-core.rules` and `naxsi-wordpress.rules` are erased after build, if you have a personnal rules, create a new file into `naxsi` folder.
+
+Settings example:
+```Shell
+# Into nginx.conf
+http {
+    include /etc/nginx/naxsi/naxsi-core.rules;
+}
+
+# Into vhost.conf
+location / {
+    try_files $uri $uri/ /index.php?$args;
+    SecRulesEnabled;
+    CheckRule "$SQL >= 10" BLOCK;
+    CheckRule "$RFI >= 10" BLOCK;
+    CheckRule "$TRAVERSAL >= 5" BLOCK;
+    CheckRule "$EVADE >= 5" BLOCK;
+    CheckRule "$XSS >= 10" BLOCK;
+    DeniedUrl "/naxsi.html"; 
+    include   /etc/nginx/naxsi/naxsi-wordpress.rules;
+}
+```
+
+For `DeniedUrl`, create `naxsi.html` into root directory.
+
 ## Features
 * Builds and installs Nginx with its dependencies in a single step.
 * Uses the latest stable/LTS versions of the software.

--- a/README.md
+++ b/README.md
@@ -2,35 +2,6 @@
 
 Build and install [Nginx](https://nginx.org) on any UNIX system with the latest version of [OpenSSL](https://www.openssl.org/) to support [ALPN](https://en.wikipedia.org/wiki/Application-Layer_Protocol_Negotiation), and therefore [HTTP/2](https://en.wikipedia.org/wiki/HTTP/2).
 
-## Modules
-
-### Naxsi
-
-[Naxsi](https://www.nbs-system.com/securite-informatique/outils-securite-informatique-open-source/naxsi/) is a web application firewall based in rules files. The module is optional, for enable it, change "no" to "yes" into `data/extras.sh`. It's just a module and default rules (warning, the files `naxsi-core.rules` and `naxsi-wordpress.rules` are erased after build, if you have a personnal rules, create a new file into `naxsi` folder.
-
-Settings example:
-```Shell
-# Into nginx.conf
-http {
-    include /etc/nginx/naxsi/naxsi-core.rules;
-}
-
-# Into vhost.conf
-location / {
-    try_files $uri $uri/ /index.php?$args;
-    SecRulesEnabled;
-    CheckRule "$SQL >= 10" BLOCK;
-    CheckRule "$RFI >= 10" BLOCK;
-    CheckRule "$TRAVERSAL >= 5" BLOCK;
-    CheckRule "$EVADE >= 5" BLOCK;
-    CheckRule "$XSS >= 10" BLOCK;
-    DeniedUrl "/naxsi.html"; 
-    include   /etc/nginx/naxsi/naxsi-wordpress.rules;
-}
-```
-
-For `DeniedUrl`, create `naxsi.html` into root directory.
-
 ## Features
 * Builds and installs Nginx with its dependencies in a single step.
 * Uses the latest stable/LTS versions of the software.
@@ -66,6 +37,38 @@ sh compile.sh
 ```
 
 If you want to build the latest mainline Nginx version instead of the stable one, comment and uncomment the corresponding lines of the `data/versions.sh` file. Do the same if you want to use the latest stable OpenSSL version instead of the LTS (long term support) one.
+
+## Modules
+
+There are extra modules that you can optionally install by editing the file `data/extras.sh`.
+
+### Naxsi
+
+[Naxsi](https://www.nbs-system.com/securite-informatique/outils-securite-informatique-open-source/naxsi/) is a web application firewall based on sets of rules. To enable it, edit the file `data/extras.sh` and set the `INSTALL_NAXSI` variable to `yes`.
+
+Settings example for `nginx.conf`:
+```Nginx
+http {
+    include /etc/nginx/naxsi/naxsi-core.rules;
+}
+```
+
+Settings example for `conf.d/*.conf`:
+```Nginx
+location / {
+    try_files $uri $uri/ /index.php?$query_string;
+    SecRulesEnabled;
+    CheckRule "$SQL >= 10" BLOCK;
+    CheckRule "$RFI >= 10" BLOCK;
+    CheckRule "$TRAVERSAL >= 5" BLOCK;
+    CheckRule "$EVADE >= 5" BLOCK;
+    CheckRule "$XSS >= 10" BLOCK;
+    DeniedUrl "/naxsi.html"; 
+    include   /etc/nginx/naxsi/naxsi-wordpress.rules;
+}
+```
+
+For the `DeniedUrl` rule to work, create a file named `naxsi.html` in the root directory.
 
 ## License
 This software is distributed under the MIT license. Please read `LICENSE` for information on the software availability and distribution.

--- a/compile.sh
+++ b/compile.sh
@@ -39,7 +39,7 @@ rm -f $ZLIB.tar.gz
 if [ ${INSTALL_NAXSI} == "yes" ]; then
     rm -Rf naxsi*
     git clone https://github.com/nbs-system/naxsi.git --branch http2
-    ngx_naxsi_module="--add-module=../naxsi_src/ "
+    ngx_naxsi_module="--add-module=../naxsi/naxsi_src/ "
 else
     ngx_naxsi_module=""
 fi

--- a/compile.sh
+++ b/compile.sh
@@ -97,6 +97,23 @@ cd $NGINX
 make -j $(nproc)
 make install
 
+## Naxsi rules
+if [ "${INSTALL_NAXSI}" == "yes" ]; then
+    if [ ! -e "/etc/nginx/naxsi" ]; then
+        mkdir -p /etc/nginx/naxsi
+    fi
+
+    # Download core rules
+    wget -q -O /etc/nginx/naxsi/naxsi-core.rules https://raw.githubusercontent.com/nbs-system/naxsi/master/naxsi_config/naxsi_core.rules
+
+    # Download wordpress rules
+    wget -q -O /etc/nginx/naxsi/naxsi-wordpress.rules https://raw.githubusercontent.com/nbs-system/naxsi-rules/master/wordpress.rules
+
+    # Download drupal rules
+    wget -q -O /etc/nginx/naxsi/naxsi-drupal.rules https://raw.githubusercontent.com/nbs-system/naxsi-rules/master/drupal.rules
+
+fi
+
 ## Cleanup
 cd ..
 rm -rf $NGINX $OPENSSL $PCRE $ZLIB naxsi*

--- a/compile.sh
+++ b/compile.sh
@@ -3,6 +3,9 @@
 ## Import software versions
 source 'data/versions.sh'
 
+## Import extras modules
+source 'data/extras.sh'
+
 ## File/directory names
 NGINX="nginx-$NGINX_VERSION"
 OPENSSL="openssl-$OPENSSL_VERSION"
@@ -32,10 +35,20 @@ wget -q http://zlib.net/$ZLIB.tar.gz
 tar -xzf $ZLIB.tar.gz
 rm -f $ZLIB.tar.gz
 
+## Download module Naxsi with http2 supported (optional)
+if [ ${INSTALL_NAXSI} == "yes" ]; then
+    rm -Rf naxsi*
+    git clone https://github.com/nbs-system/naxsi.git --branch http2
+    ngx_naxsi_module="--add-module=../naxsi_src/ "
+else
+    ngx_naxsi_module=""
+fi
+
 ## Configure, compile and install
 cd $NGINX
 
 ./configure \
+    ${ngx_naxsi_module} \
 	--prefix=/usr/local/nginx \
 	--sbin-path=/usr/sbin/nginx \
 	--conf-path=/etc/nginx/nginx.conf \
@@ -86,4 +99,4 @@ make install
 
 ## Cleanup
 cd ..
-rm -rf $NGINX $OPENSSL $PCRE $ZLIB
+rm -rf $NGINX $OPENSSL $PCRE $ZLIB naxsi*

--- a/compile.sh
+++ b/compile.sh
@@ -3,7 +3,7 @@
 ## Import software versions
 source 'data/versions.sh'
 
-## Import extras modules
+## Import extra modules
 source 'data/extras.sh'
 
 ## File/directory names

--- a/compile.sh
+++ b/compile.sh
@@ -103,13 +103,19 @@ if [ "${INSTALL_NAXSI}" == "yes" ]; then
     fi
 
     # Download core rules
-    wget -q -O /etc/nginx/naxsi/naxsi-core.rules https://raw.githubusercontent.com/nbs-system/naxsi/master/naxsi_config/naxsi_core.rules
+    if [ ! -e "/etc/nginx/naxsi/naxsi-core.rules" ]; then
+        wget -q -O /etc/nginx/naxsi/naxsi-core.rules https://raw.githubusercontent.com/nbs-system/naxsi/master/naxsi_config/naxsi_core.rules
+	fi
 
     # Download WordPress rules
-    wget -q -O /etc/nginx/naxsi/naxsi-wordpress.rules https://raw.githubusercontent.com/nbs-system/naxsi-rules/master/wordpress.rules
+    if [ ! -e "/etc/nginx/naxsi/naxsi-wordpress.rules" ]; then
+        wget -q -O /etc/nginx/naxsi/naxsi-wordpress.rules https://raw.githubusercontent.com/nbs-system/naxsi-rules/master/wordpress.rules
+	fi
 
     # Download Drupal rules
-    wget -q -O /etc/nginx/naxsi/naxsi-drupal.rules https://raw.githubusercontent.com/nbs-system/naxsi-rules/master/drupal.rules
+    if [ ! -e "/etc/nginx/naxsi/naxsi-drupal.rules" ]; then
+        wget -q -O /etc/nginx/naxsi/naxsi-drupal.rules https://raw.githubusercontent.com/nbs-system/naxsi-rules/master/drupal.rules
+    fi
 fi
 
 ## Cleanup

--- a/compile.sh
+++ b/compile.sh
@@ -94,7 +94,7 @@ cd $NGINX
 	--with-zlib=/usr/local/src/$ZLIB \
 	--with-cc-opt='-O2 -g -pipe -Wall -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -m64 -mtune=generic'
 
-make
+make -j $(nproc)
 make install
 
 ## Cleanup

--- a/compile.sh
+++ b/compile.sh
@@ -35,20 +35,19 @@ wget -q http://zlib.net/$ZLIB.tar.gz
 tar -xzf $ZLIB.tar.gz
 rm -f $ZLIB.tar.gz
 
-## Download module Naxsi with http2 supported (optional)
+## Download NAXSI module (optional)
 if [ ${INSTALL_NAXSI} == "yes" ]; then
-    rm -Rf naxsi*
     git clone https://github.com/nbs-system/naxsi.git --branch http2
-    ngx_naxsi_module="--add-module=../naxsi/naxsi_src/ "
+    NAXSI_MODULE="--add-module=../naxsi/naxsi_src"
 else
-    ngx_naxsi_module=""
+    NAXSI_MODULE=""
 fi
 
 ## Configure, compile and install
 cd $NGINX
 
 ./configure \
-    ${ngx_naxsi_module} \
+    ${NAXSI_MODULE} \
 	--prefix=/usr/local/nginx \
 	--sbin-path=/usr/sbin/nginx \
 	--conf-path=/etc/nginx/nginx.conf \
@@ -106,12 +105,11 @@ if [ "${INSTALL_NAXSI}" == "yes" ]; then
     # Download core rules
     wget -q -O /etc/nginx/naxsi/naxsi-core.rules https://raw.githubusercontent.com/nbs-system/naxsi/master/naxsi_config/naxsi_core.rules
 
-    # Download wordpress rules
+    # Download WordPress rules
     wget -q -O /etc/nginx/naxsi/naxsi-wordpress.rules https://raw.githubusercontent.com/nbs-system/naxsi-rules/master/wordpress.rules
 
-    # Download drupal rules
+    # Download Drupal rules
     wget -q -O /etc/nginx/naxsi/naxsi-drupal.rules https://raw.githubusercontent.com/nbs-system/naxsi-rules/master/drupal.rules
-
 fi
 
 ## Cleanup

--- a/data/extras.sh
+++ b/data/extras.sh
@@ -1,2 +1,7 @@
-# Choose if install module WAF Naxsi
+#!/usr/bin/env bash
+
+## Extra modules (you can edit this file to enable them)
+
+# NAXSI (anti XSS and SQL injection)
+# https://github.com/nbs-system/naxsi
 INSTALL_NAXSI="no"

--- a/data/extras.sh
+++ b/data/extras.sh
@@ -1,0 +1,2 @@
+# Choose if install module WAF Naxsi
+INSTALL_NAXSI="no"

--- a/data/versions.sh
+++ b/data/versions.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
 ## Software versions (you can edit this if there are newer versions)
-## Updated: 2017-05-28
+## Updated: 2017-07-12
 
 # Nginx
-#NGINX_VERSION="1.13.3" # 2017-06-27 (mainline)
-NGINX_VERSION="1.12.1" # 2017-04-12 (stable)
+#NGINX_VERSION="1.13.3" # 2017-07-11 (mainline)
+NGINX_VERSION="1.12.1" # 2017-07-11 (stable)
 
 # OpenSSL
 #OPENSSL_VERSION="1.1.0f" # 2017-05-25 (stable)

--- a/data/versions.sh
+++ b/data/versions.sh
@@ -4,7 +4,7 @@
 ## Updated: 2017-05-28
 
 # Nginx
-#NGINX_VERSION="1.13.0" # 2017-04-25 (mainline)
+#NGINX_VERSION="1.13.2" # 2017-06-27 (mainline)
 NGINX_VERSION="1.12.0" # 2017-04-12 (stable)
 
 # OpenSSL

--- a/data/versions.sh
+++ b/data/versions.sh
@@ -4,8 +4,8 @@
 ## Updated: 2017-05-28
 
 # Nginx
-#NGINX_VERSION="1.13.2" # 2017-06-27 (mainline)
-NGINX_VERSION="1.12.0" # 2017-04-12 (stable)
+#NGINX_VERSION="1.13.3" # 2017-06-27 (mainline)
+NGINX_VERSION="1.12.1" # 2017-04-12 (stable)
 
 # OpenSSL
 #OPENSSL_VERSION="1.1.0f" # 2017-05-25 (stable)

--- a/dependencies/debian-ubuntu.sh
+++ b/dependencies/debian-ubuntu.sh
@@ -5,4 +5,4 @@
 # https://wiki.debian.org/BuildingTutorial
 # https://help.ubuntu.com/community/CompilingSoftware
 
-apt -y install build-essential automake checkinstall wget
+apt -y install build-essential automake checkinstall wget git

--- a/dependencies/rhel-centos.sh
+++ b/dependencies/rhel-centos.sh
@@ -2,4 +2,4 @@
 
 ## Install CentOS dependencies
 yum -y groupinstall 'Development Tools'
-yum -y install wget
+yum -y install wget git


### PR DESCRIPTION
## Description

Add support **Naxsi** module with http2. 
Replace "no" (default) to "yes" for use it on data/extras.sh file.
Download defaults rules (core + wordpress + drupal) into `/etc/nginx/naxsi` directory.

## Dependencies

Add **git** on dependencies scripts (debian/redhat based)

## Other

* Add nproc option into make
* Update Nginx stable/mainline version
* Update `README.md` with Naxsi settings