### PR TITLE
Add TLSv1.3 support with OpenSSL development

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Run the main script and Nginx will be automatically compiled and installed in yo
 sh compile.sh
 ```
 
-If you want to build the latest mainline Nginx version instead of the stable one, comment and uncomment the corresponding lines of the `data/versions.sh` file. Do the same if you want to use the latest stable OpenSSL version instead of the LTS (long term support) one.
+If you want to build the latest mainline Nginx version instead of the stable one, comment and uncomment the corresponding lines of the `data/versions.sh` file. Do the same if you want to use the latest stable OpenSSL version instead of the LTS (long term support) one. If you want to support TLS 1.3 (that is a development feature), follow the instructions of the `data/versions.sh` file.
 
 ## Modules
 

--- a/compile.sh
+++ b/compile.sh
@@ -19,6 +19,7 @@ cd /usr/local/src
 wget -q https://nginx.org/download/$NGINX.tar.gz
 tar -xzf $NGINX.tar.gz
 rm -f $NGINX.tar.gz
+
 if [ $OPENSSL_VERSION == "tls1.3" ]; then
   cd $NGINX
   wget -q https://raw.githubusercontent.com/cujanovic/nginx-dynamic-tls-records-patch/master/nginx__dynamic_tls_records_1.11.5%2B.patch

--- a/compile.sh
+++ b/compile.sh
@@ -19,11 +19,24 @@ cd /usr/local/src
 wget -q https://nginx.org/download/$NGINX.tar.gz
 tar -xzf $NGINX.tar.gz
 rm -f $NGINX.tar.gz
+if [ $OPENSSL_VERSION == "tls1.3" ]; then
+  cd $NGINX
+  wget -q https://raw.githubusercontent.com/cujanovic/nginx-dynamic-tls-records-patch/master/nginx__dynamic_tls_records_1.11.5%2B.patch
+  patch -p1 < nginx__dynamic_tls_records_1.11.5*.patch
+  cd ..
+fi
 
 ## Download OpenSSL
-wget -q https://www.openssl.org/source/$OPENSSL.tar.gz
-tar -xzf $OPENSSL.tar.gz
-rm -f $OPENSSL.tar.gz
+if [ $OPENSSL_VERSION == "tls1.3" ]; then
+  git clone https://github.com/openssl/openssl.git $OPENSSL
+  cd $OPENSSL
+  git checkout tls1.3-draft-18
+  cd ..
+else
+  wget -q https://www.openssl.org/source/$OPENSSL.tar.gz
+  tar -xzf $OPENSSL.tar.gz
+  rm -f $OPENSSL.tar.gz
+fi
 
 ## Download PCRE
 wget -q https://ftp.pcre.org/pub/pcre/$PCRE.tar.gz

--- a/compile.sh
+++ b/compile.sh
@@ -32,6 +32,7 @@ if [ $OPENSSL_VERSION == "tls1.3" ]; then
   cd $OPENSSL
   git checkout tls1.3-draft-18
   cd ..
+  OPENSSL_OPTS="--with-openssl-opt=enable-tls1_3"
 else
   wget -q https://www.openssl.org/source/$OPENSSL.tar.gz
   tar -xzf $OPENSSL.tar.gz
@@ -114,7 +115,7 @@ cd $NGINX
 	--with-http_v2_module \
 	--with-mail \
 	--with-mail_ssl_module \
-	--with-openssl=/usr/local/src/$OPENSSL \
+	--with-openssl=/usr/local/src/$OPENSSL $OPENSSL_OPTS \
 	--with-pcre=/usr/local/src/$PCRE \
 	--with-pcre-jit \
 	--with-stream \

--- a/data/versions.sh
+++ b/data/versions.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 ## Software versions (you can edit this if there are newer versions)
-## Updated: 2017-10-13
+## Updated: 2017-10-28
 
 # Nginx
 #NGINX_VERSION="1.13.5" # 2017-09-05 (mainline)

--- a/data/versions.sh
+++ b/data/versions.sh
@@ -7,15 +7,18 @@
 #NGINX_VERSION="1.13.5" # 2017-09-05 (mainline)
 NGINX_VERSION="1.12.1" # 2017-07-11 (stable)
 
-# OpenSSL TLSv1.3 support
-# Warning it is a development version and based into draft18 branch (latest is 1.1.1-dev)
-# Add ciphers "TLS13-AES-128-GCM-SHA256 TLS13-AES-256-GCM-SHA384 TLS13-CHACHA20-POLY1305-SHA256"
-# Add protocol "TLSv1.3"
-#OPENSSL_VERSION="tls1.3"
-
 # OpenSSL
+#OPENSSL_VERSION="tls1.3" # latest development version with TLS 1.3 support
 #OPENSSL_VERSION="1.1.0f" # 2017-05-25 (stable)
 OPENSSL_VERSION="1.0.2l" # 2017-05-25 (long term support)
+
+# [About OpenSSL with TLSv1.3 support]
+#
+# It is a development version and it is based on the "draft18" branch.
+#
+# Specific Nginx settings are required:
+# - Add protocol "TLSv1.3" to the directive "ssl_protocols".
+# - Add ciphers "TLS13-AES-128-GCM-SHA256 TLS13-AES-256-GCM-SHA384 TLS13-CHACHA20-POLY1305-SHA256" to the directive "ssl_ciphers".
 
 # PCRE
 PCRE_VERSION="8.41" # 2017-07-05 (old stable, latest supported by Nginx)

--- a/data/versions.sh
+++ b/data/versions.sh
@@ -7,8 +7,13 @@
 #NGINX_VERSION="1.13.5" # 2017-09-05 (mainline)
 NGINX_VERSION="1.12.1" # 2017-07-11 (stable)
 
+# OpenSSL TLSv1.3 support
+# Warning it is a development version and based into draft18 branch (latest is 1.1.1-dev)
+# Add ciphers "TLS13-AES-128-GCM-SHA256 TLS13-AES-256-GCM-SHA384 TLS13-CHACHA20-POLY1305-SHA256"
+# Add protocol "TLSv1.3"
+#OPENSSL_VERSION="tls1.3"
+
 # OpenSSL
-#OPENSSL_VERSION="tls1.3" # Use development version (1.1.1-dev) and specific branch draft18 for tls1.3 support (development)
 #OPENSSL_VERSION="1.1.0f" # 2017-05-25 (stable)
 OPENSSL_VERSION="1.0.2l" # 2017-05-25 (long term support)
 

--- a/data/versions.sh
+++ b/data/versions.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 
 ## Software versions (you can edit this if there are newer versions)
-## Updated: 2017-09-26
+## Updated: 2017-10-13
 
 # Nginx
 #NGINX_VERSION="1.13.5" # 2017-09-05 (mainline)
 NGINX_VERSION="1.12.1" # 2017-07-11 (stable)
 
 # OpenSSL
+#OPENSSL_VERSION="tls1.3" # Use development version (1.1.1-dev) and specific branch draft18 for tls1.3 support (development)
 #OPENSSL_VERSION="1.1.0f" # 2017-05-25 (stable)
 OPENSSL_VERSION="1.0.2l" # 2017-05-25 (long term support)
 


### PR DESCRIPTION
## Description

Using development of OpenSSL (latest is 1.1.1-dev) and draft18 branch for support TLS1.3.
Enable this version into `data/versions.sh` file.

## Return

```bash
nginx version: nginx/1.13.5
built by gcc 4.8.5 20150623 (Red Hat 4.8.5-16) (GCC)
built with OpenSSL 1.1.1-dev  xx XXX xxxx
```